### PR TITLE
Replace console.err with console.error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 redis/*
 sentinel/*
 npm-debug.log
+*.swp
 
 # macos
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-- '0.10'
+- '10'
+- '12'
 services:
 - redis-server
 script:

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function start_redis(port, slaveof) {
 
   if(!silent) console.log('Starting redis:'+port);
   if(!which('redis-server')) {
-    console.err('Please install redis >2.8.4');
+    console.error('Please install redis >2.8.4');
     return(1);
   }
 
@@ -33,11 +33,11 @@ function start_redis(port, slaveof) {
 
   if (exec(redis_start).code !== 0) {
     if(test('-f', redis_log_file)) {
-      console.err('Failed to start redis. Here\'s the log:');
+      console.error('Failed to start redis. Here\'s the log:');
       cat(redis_log_file);
       return(1);
     }
-    console.err('Failed to start redis, bailing...');
+    console.error('Failed to start redis, bailing...');
     return(1);
   }
 
@@ -45,11 +45,11 @@ function start_redis(port, slaveof) {
 
   if(!redis_alive(port)) {
     if(test('-f', redis_log_file)) {
-      console.err('Redis failed ping, Here\'s the log:');
+      console.error('Redis failed ping, Here\'s the log:');
       cat(redis_log_file);
       return(1);
     }
-    console.err('Redis failed ping, bailing...');
+    console.error('Redis failed ping, bailing...');
     return(1);
   }
   if(!silent) console.log('success');
@@ -104,11 +104,11 @@ function start_sentinel(port, master_host, master_port) {
   if(!silent) console.log('Starting sentinel:'+port);
   if(exec(sentinel_start).code !== 0) {
     if(test('-f', sentinel_log_file)) {
-      console.err('Failed to start sentinel. Here\'s the log:');
+      console.error('Failed to start sentinel. Here\'s the log:');
       cat(sentinel_log_file);
       return(1);
     }
-    console.err('Failed to start sentinel, bailing...');
+    console.error('Failed to start sentinel, bailing...');
     return(1);
   }
 
@@ -116,11 +116,11 @@ function start_sentinel(port, master_host, master_port) {
 
   if(!sentinel_alive(port)) {
     if(test('-f', sentinel_log_file)) {
-      console.err('Sentinel failed ping. Here\'s the log:');
+      console.error('Sentinel failed ping. Here\'s the log:');
       cat(sentinel_log_file);
       return(1);
     }
-    console.err('Sentinel failed ping, bailing...');
+    console.error('Sentinel failed ping, bailing...');
     return(1);
   }
   if (!silent) console.log('success');


### PR DESCRIPTION
cc @zendesk/radar @vanchi-zendesk 

## Description

While updating to Github Actions in https://github.com/zendesk/zendesk_radar/pull/438, we found that this exception was raised when hitting `console.err`. Replacing with the correct `console.error`